### PR TITLE
Atualiza script de download de fotos para 2022

### DIFF
--- a/fotos.py
+++ b/fotos.py
@@ -2,8 +2,10 @@ from urllib.parse import urljoin
 from pathlib import Path
 from zipfile import ZipFile
 
-from rows.utils import download_file, import_from_uri
+from rows.utils import download_file
 from tqdm import tqdm
+
+from utils import is_municipal_elections_year
 
 
 data_path = Path("fotos")
@@ -13,46 +15,107 @@ for path in (data_path, download_path, output_path):
     if not path.exists():
         path.mkdir(parents=True)
 
+STATES = [
+    "AC",
+    "AL",
+    "AM",
+    "AP",
+    "BA",
+    "BR",
+    "CE",
+    "DF",
+    "ES",
+    "GO",
+    "MA",
+    "MG",
+    "MS",
+    "MT",
+    "PA",
+    "PB",
+    "PE",
+    "PI",
+    "PR",
+    "RJ",
+    "RN",
+    "RO",
+    "RR",
+    "RS",
+    "SC",
+    "SE",
+    "SP",
+    "TO",
+]
+
+
+def main():
+    for year in range(2014, 2022 + 1, 2):
+        download_photos(year)
+
 
 def download_photos(year):
-    year = str(year)
-    url = f"http://agencia.tse.jus.br/estatistica/sead/eleicoes/eleicoes{year}/fotos/"
-    table = import_from_uri(url)
-    for row in table:
-        if row.name == "Parent Directory":
+    base_url = f"https://cdn.tse.jus.br/estatistica/sead/eleicoes/eleicoes{year}/fotos/"
+    download_filenames = get_download_filenames(year)
+
+    for download_filename in download_filenames:
+        filepath = download_path / str(year) / download_filename
+        url = urljoin(base_url, download_filename)
+        download(url, filepath)
+
+        photo_path = output_path / str(year)
+        extract(filepath, photo_path)
+
+
+def get_download_filenames(year):
+    if year == 2014:
+        return [f"foto_cand{year}_div.zip"]
+
+    download_filenames = []
+    for state in STATES:
+        if state in ["BR", "DF"] and is_municipal_elections_year(year):
             continue
 
-        filename = download_path / year / row.name
-        print(f"Downloading {filename.name}", end="")
-        if filename.exists():
-            print(" - downloaded already, skipping.")
-        else:
-            if not filename.parent.exists():
-                filename.parent.mkdir(parents=True)
-            print()
-            download_file(urljoin(url, row.name), progress=True, filename=filename)
-            print(f"  saved: {filename}")
+        download_filenames.append(f"foto_cand{year}_{state}_div.zip")
 
-        photo_path = output_path / year
-        if not photo_path.exists():
-            photo_path.mkdir(parents=True)
-        print(f"  Exporting to: {photo_path}")
-        zf = ZipFile(filename)
-        for file_info in tqdm(zf.filelist, desc="Exporting pictures"):
-            internal_name = file_info.filename
-            internal_path = Path(internal_name)
-            extension = internal_path.name.split(".")[-1].lower()
-            info = internal_path.name.split(".")[0].split("_")[0]
-            state, sequence_number = info[1:3], info[3:]
-            new_filename = photo_path / state / f"{sequence_number}.{extension}"
+    return download_filenames
 
-            if not new_filename.parent.exists():
-                new_filename.parent.mkdir(parents=True)
-            zfobj = zf.open(internal_name)
-            with open(new_filename, mode="wb") as fobj:
-                fobj.write(zfobj.read())
+
+def download(download_url, download_path):
+    print(f"Downloading {download_path.name}", end="")
+    if download_path.exists():
+        print(" - downloaded already, skipping.")
+    else:
+        if not download_path.parent.exists():
+            download_path.parent.mkdir(parents=True)
+        print()
+        download_file(
+            download_url, progress=True, filename=download_path, user_agent="Mozilla/4"
+        )
+        print(f"  saved: {download_path}")
+
+
+def extract(source_path, extract_path):
+    if not extract_path.exists():
+        extract_path.mkdir(parents=True)
+
+    print(f"  Exporting to: {extract_path}")
+    zf = ZipFile(source_path)
+
+    for file_info in tqdm(zf.filelist, desc="Exporting pictures"):
+        internal_name = file_info.filename
+        internal_path = Path(internal_name)
+        extension = internal_path.name.split(".")[-1].lower()
+        info = internal_path.name.split(".")[0].split("_")[0]
+        state, sequence_number = info[1:3], info[3:]
+        new_filename = extract_path / state / f"{sequence_number}.{extension}"
+
+        if not new_filename.parent.exists():
+            new_filename.parent.mkdir(parents=True)
+
+        zfobj = zf.open(internal_name)
+
+        with open(new_filename, mode="wb") as fobj:
+            fobj.write(zfobj.read())
 
 
 if __name__ == "__main__":
-    for year in range(2012, 2018 + 1, 2):
-        download_photos(year)
+    main()

--- a/utils.py
+++ b/utils.py
@@ -35,7 +35,6 @@ def merge_zipfiles(filename1, filename2):
             zip1.writestr(filename, zip2.open(filename).read())
 
 
-
 class FixQuotes(io.TextIOWrapper):
     def readline(self, *args, **kwargs):
         data = super().readline(*args, **kwargs)
@@ -46,3 +45,7 @@ class FixQuotes(io.TextIOWrapper):
         if '";"' in data and not data.startswith('"') and not data.endswith('"'):
             data = '"' + data[:- len(newline)] + '"' + newline
         return data
+
+
+def is_municipal_elections_year(year):
+    return True if year % 4 == 0 else False


### PR DESCRIPTION
Como o TSE disponibiliza arquivos a partir do Portal de Dados Abertos a partir dessas eleições, as fotos das eleições de 2022 não conseguem ser baixadas pela URL antiga.

Este commit atualiza o script de download, mas uma ressalva que ainda precisa ser investigada é a impossibilidade de baixar fotos das eleições de 2012 a partir dessa nova fonte.